### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax/popupscript.php
+++ b/syntax/popupscript.php
@@ -27,7 +27,7 @@ class syntax_plugin_popupviewer_popupscript extends DokuWiki_Syntax_Plugin {
         $this->Lexer->addExitPattern('</popupscript>', 'plugin_popupviewer_popupscript');
     }
 
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
     	if ( $state == DOKU_LEXER_UNMATCHED ) {
 	    	return $match;
     	}
@@ -35,7 +35,7 @@ class syntax_plugin_popupviewer_popupscript extends DokuWiki_Syntax_Plugin {
     	return false;
     }
 
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
 
 		global $ID;
 

--- a/syntax/viewer.php
+++ b/syntax/viewer.php
@@ -36,7 +36,7 @@ class syntax_plugin_popupviewer_viewer extends DokuWiki_Syntax_Plugin {
         $this->Lexer->addSpecialPattern('{{popupclose>[^}]+}}', $mode, 'plugin_popupviewer_viewer');
     }
 
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
 
         $close = strstr( $match, "{{popupclose>") !== false;
 
@@ -58,7 +58,7 @@ class syntax_plugin_popupviewer_viewer extends DokuWiki_Syntax_Plugin {
         return array(trim($id), $name, $title, $w, $h, $orig, $close, null, $keepOpen);
     }
 
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         global $ID, $conf, $JSINFO;
 
         list($id, $name, $title, $w, $h, $orig, $close, $isImageMap, $keepOpen) = $data;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.