### PR TITLE
Fix warnings "Undefined variable" & "Undefined array key 1"

### DIFF
--- a/action.php
+++ b/action.php
@@ -7,6 +7,8 @@
  * @author     Gerry Weissbach <gweissbach@inetsoftware.de>
  */
 
+use dokuwiki\Extension\Event;
+
 // must be run within Dokuwiki
 if(!defined('DOKU_INC')) die();
 
@@ -69,12 +71,11 @@ class action_plugin_popupviewer extends DokuWiki_Action_Plugin {
         switch($event->data) {
             case '_popup_load_file' :
                 $INFO = pageinfo();
-                $json = new JSON();
                 $JSINFO['id'] = $ID;
                 $JSINFO['namespace'] = (string) $INFO['namespace'];
-                trigger_event('POPUPVIEWER_DOKUWIKI_STARTED',$head,null,true);
+                Event::createAndTrigger('POPUPVIEWER_DOKUWIKI_STARTED',$head,null,true);
 
-                $script = 'var JSINFO = '.$json->encode($JSINFO).';';
+                $script = 'var JSINFO = ' . json_encode($JSINFO) . ';';
                 
                 if ( $this->getConf('allowpopupscript') ) {
                     $popupscript = p_get_metadata($ID, 'popupscript', true);
@@ -109,7 +110,7 @@ class action_plugin_popupviewer extends DokuWiki_Action_Plugin {
         header('Content-Type: text/html; charset=utf-8');
 
         if ( !empty($head['popupscript']) ) {
-            trigger_event('TPL_METAHEADER_OUTPUT',$head,'_tpl_metaheaders_action',true);
+            Event::createAndTrigger('TPL_METAHEADER_OUTPUT',$head,'_tpl_metaheaders_action',true);
         }
 
         print $data;

--- a/syntax/viewer.php
+++ b/syntax/viewer.php
@@ -38,13 +38,21 @@ class syntax_plugin_popupviewer_viewer extends DokuWiki_Syntax_Plugin {
 
     function handle($match, $state, $pos, Doku_Handler $handler) {
 
+        global $ID;
+
         $close = strstr( $match, "{{popupclose>") !== false;
 
         $orig = substr($match, $close ? 13 : 8, -2);
-        list($id, $name) = explode('|', $orig, 2); // find ID/Params + Name Extension
-        list($name, $title) = explode('%', $name, 2); // find Name and Title
-        list($id, $param) = explode('?', $id, 2); // find ID + Params
-        
+        $partId = explode('|', $orig, 2); // find ID/Params + Name Extension
+        $id = $partId[0];
+        $name = $partId[1] ?? '';
+        $partName = explode('%', $name, 2); // find Name and Title
+        $name = $partName[0];
+        $title = $part[1] ?? '';
+        $partParam = explode('?', $id, 2); // find ID + Params
+        $id = $partParam[0];
+        $param = $partParam[1] ?? '';
+
         $params = explode('&', strtolower($param));
         $w = $h = $keepOpen = null;
         foreach( $params as $p ) {


### PR DESCRIPTION
Multiple warnings in Dokuwiki logs:

E_WARNING: Undefined variable $ID/opt/www/wiki/lib/plugins/popupviewer/syntax/viewer.php(62)
E_WARNING: Undefined array key 1/opt/www/wiki/lib/plugins/popupviewer/syntax/viewer.php(47)

